### PR TITLE
fix: change path params with pattern

### DIFF
--- a/boot/gw_server_options.go
+++ b/boot/gw_server_options.go
@@ -166,30 +166,32 @@ func NewRkGwServerMuxOptions(mOptIn *protojson.MarshalOptions, uOptIn *protojson
 			MarshalOptions:   *mOpt,
 			UnmarshalOptions: *uOpt,
 		}),
-		runtime.WithMetadata(func(c context.Context, req *http.Request) metadata.MD {
-			// we are unable to get scheme with req.URL.Scheme.
-			// Let's check with TLS.
-			scheme := "http"
-			if req.TLS != nil {
-				scheme = "https"
-			}
-
-			md := metadata.Pairs(
-				"x-forwarded-method", req.Method,
-				"x-forwarded-path", req.URL.Path,
-				"x-forwarded-scheme", scheme,
-				"x-forwarded-remote-addr", req.RemoteAddr,
-				"x-forwarded-user-agent", req.UserAgent())
-			if pattern, ok := runtime.HTTPPathPattern(c); ok {
-				md["x-forwarded-pattern"] = []string{pattern}
-			}
-
-			return md
-		}),
+		runtime.WithMetadata(rkGwMetadataBuilder),
 
 		runtime.WithOutgoingHeaderMatcher(OutgoingHeaderMatcher),
 		runtime.WithIncomingHeaderMatcher(IncomingHeaderMatcher),
 	}
+}
+
+func rkGwMetadataBuilder(c context.Context, req *http.Request) metadata.MD {
+	// we are unable to get scheme with req.URL.Scheme.
+	// Let's check with TLS.
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+
+	md := metadata.Pairs(
+		"x-forwarded-method", req.Method,
+		"x-forwarded-path", req.URL.Path,
+		"x-forwarded-scheme", scheme,
+		"x-forwarded-remote-addr", req.RemoteAddr,
+		"x-forwarded-user-agent", req.UserAgent())
+	if pattern, ok := runtime.HTTPPathPattern(c); ok {
+		md["x-forwarded-pattern"] = []string{pattern}
+	}
+
+	return md
 }
 
 // HttpErrorHandler Mainly copies from runtime.DefaultHTTPErrorHandler.

--- a/middleware/common.go
+++ b/middleware/common.go
@@ -8,13 +8,14 @@ package rkgrpcmid
 
 import (
 	"context"
-	"github.com/rookie-ninja/rk-entry/v2/middleware"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/peer"
 	"net"
 	"path"
 	"strings"
+
+	rkmid "github.com/rookie-ninja/rk-entry/v2/middleware"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 var (
@@ -42,7 +43,7 @@ func GetGwInfo(md metadata.MD) (gwMethod, gwPath, gwScheme, gwUserAgent string) 
 		gwMethod = tokens[0]
 	}
 
-	if tokens := md["x-forwarded-path"]; len(tokens) > 0 {
+	if tokens := md["x-forwarded-pattern"]; len(tokens) > 0 {
 		gwPath = tokens[0]
 	}
 

--- a/middleware/common_test.go
+++ b/middleware/common_test.go
@@ -7,10 +7,11 @@ package rkgrpcmid
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
-	"testing"
 )
 
 type FakeAddr struct{}
@@ -26,14 +27,14 @@ func (f FakeAddr) String() string {
 func TestGetGwInfo(t *testing.T) {
 	md := metadata.New(map[string]string{
 		"x-forwarded-method":     "ut-method",
-		"x-forwarded-path":       "ut-path",
 		"x-forwarded-scheme":     "ut-scheme",
 		"x-forwarded-user-agent": "ut-agent",
+		"x-forwarded-pattern":    "ut-path/{id}",
 	})
 
 	method, path, scheme, agent := GetGwInfo(md)
 	assert.Equal(t, "ut-method", method)
-	assert.Equal(t, "ut-path", path)
+	assert.Equal(t, "ut-path/{id}", path)
 	assert.Equal(t, "ut-scheme", scheme)
 	assert.Equal(t, "ut-agent", agent)
 }


### PR DESCRIPTION
Regarding this issue https://github.com/rookie-ninja/rk-grpc/issues/97

After checking on the issue, the issue is when using resource path, memory usage of the application is increased gradually since every request that processed by service will have new entries on prometeus metrics

After check on grpc-gateway documentation 
https://grpc-ecosystem.github.io/grpc-gateway/docs/operations/annotated_context/

It seems using pattern is much more suitable, since the same pattern can be grouped on the same entries
